### PR TITLE
Ignore birth dates that don’t include a year

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -73,7 +73,8 @@ class MemberPage < Scraped::HTML
   private
 
   def datefrom(date)
-    Date.parse(date).to_s
+    stripped_date = date.sub(/^.*irth: /, '').sub(',', '').sub(/(\d)(?:st|nd|rd|th) /, '\\1 ')
+    Date.strptime(stripped_date, '%d %B %Y').to_s rescue nil
   end
 
   def role_and_name


### PR DESCRIPTION
Switch from using `Date.parse` to `Date.strptime` so we can be more prescriptive about what constitutes a valid birth date.

Refs #1.